### PR TITLE
To get meta image if there is meta name=og:image instead of property …

### DIFF
--- a/richlinkpreview/src/main/java/io/github/ponnamkarthik/richlinkpreview/RichPreview.java
+++ b/richlinkpreview/src/main/java/io/github/ponnamkarthik/richlinkpreview/RichPreview.java
@@ -88,6 +88,19 @@ public class RichPreview {
                         metaData.setImageurl(resolveURL(url, image));
                     }
                 }
+                
+                //get image from meta[name=og:image] 
+                if(Metadata.getImageurl().isEmpty())
+                    {
+                Elements imageElements = doc.select("meta[name=og:image]");
+                if(imageElements.size() > 0) {
+                    String image = imageElements.attr("content");
+                    if(!image.isEmpty()) {
+                        metaData.setImageurl(resolveURL(url, image));
+                    }
+                }
+                }
+                    
                 if(metaData.getImageurl().isEmpty()) {
                     String src = doc.select("link[rel=image_src]").attr("href");
                     if (!src.isEmpty()) {


### PR DESCRIPTION
…attribute

I got empty image url because my url contained meta name=og:image instead of property attribute.
My url is https://openload.co/f/Qtwj8fHJyns/Daredevil_S01E02.mp4
I haven't checked code please check it first